### PR TITLE
Add swagger docs service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,47 @@
+# Version control
+.git
+.gitignore
+
+# Node.js
+node_modules
+npm-debug.log
+yarn-debug.log
+yarn-error.log
+
+# Build artifacts
+build
+dist
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# Docker
+Dockerfile
+docker-compose.yml
+.dockerignore
+
+# Logs
+logs
+*.log
+
+# Editor directories and files
+.idea
+.vscode
+*.swp
+*.swo
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Data directory (will be mounted as a volume)
+data/

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,50 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: [ main, feature/docker-support ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,format=long
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ build/
 
 # Maistro specific
 data/
+.maistro-docker-config
+docker-compose.override.yml
 
 # System Files
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# Build stage
+FROM --platform=$BUILDPLATFORM node:20-alpine AS builder
+
+# Set working directory
+WORKDIR /app
+
+# Install build dependencies
+RUN apk add --no-cache git
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies
+RUN npm ci
+
+# Copy all files
+COPY . .
+
+# Production stage
+FROM --platform=$TARGETPLATFORM node:20-alpine
+ENV NODE_ENV=production
+
+# Set working directory
+WORKDIR /app
+
+# Copy package files and install production dependencies
+COPY --from=builder /app/package*.json ./
+RUN npm ci --only=production
+
+# Copy application files
+COPY --from=builder /app/src ./src
+COPY --from=builder /app/public ./public
+
+# Create data directory
+RUN mkdir -p /app/data/prompts
+
+# Copy entrypoint script
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Expose port
+EXPOSE 3000
+
+# Set entrypoint
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Each configuration allows you to define:
 
 1. Clone this repository:
 ```bash
-git clone https://github.com/yourusername/maistro.git
+git clone https://github.com/forayconsulting/maistro.git
 cd maistro
 ```
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,32 @@ This implementation allows for sophisticated workflows where different prompts c
 
 When the prompt runs, Maistro will automatically include the selected MCP servers as `--with-extension` parameters to the Goose CLI, giving your prompts access to the tools and resources provided by those servers.
 
+## REST API
+
+Maistro provides a comprehensive REST API that allows you to programmatically interact with the application. The API endpoints include:
+
+- **Configurations**: Create, read, update, and delete configurations
+- **Folders**: Manage folder structure for organizing configurations
+- **Execution**: Run configurations programmatically
+- **MCP Servers**: Manage MCP server definitions
+- **Models**: Configure LLM models and API keys
+
+### API Documentation
+
+Maistro includes interactive API documentation powered by Swagger UI. You can access the documentation at:
+
+```
+http://localhost:3000/api-docs
+```
+
+The documentation provides:
+- Complete list of all available endpoints
+- Request and response schemas
+- "Try it out" functionality to test API calls directly from the browser
+- Code examples in various languages
+
+This makes it easy to integrate Maistro with other tools and systems or build custom interfaces.
+
 ## Technical Details
 
 Maistro uses:
@@ -229,6 +255,7 @@ Maistro uses:
 - File-based storage for configurations, prompts, and MCP server definitions
 - Integration with Goose CLI's extension system for MCP servers
 - System crontab for scheduling
+- Swagger UI for API documentation
 
 ### Data Persistence
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,11 @@ Each configuration allows you to define:
 - Node.js and npm
 - [Goose CLI tool](https://github.com/xyzabc/goose) (confirmed to work with v1.0.7+)
 - Access to system crontab (for scheduling)
+- Docker and Docker Compose (for containerized deployment)
 
 ## Installation
+
+### Standard Installation
 
 1. Clone this repository:
 ```bash
@@ -41,6 +44,40 @@ npm start
 ```
 
 4. Open your browser to http://localhost:3000
+
+### Docker Installation
+
+1. Clone this repository:
+```bash
+git clone https://github.com/yourusername/maistro.git
+cd maistro
+```
+
+2. Build and run using Docker Compose:
+```bash
+# Build and start the container
+./scripts/run-local.sh
+
+# Or run in detached mode
+./scripts/run-local.sh --detached
+```
+
+3. Open your browser to http://localhost:3000
+
+#### Docker Build Options
+
+The Docker build supports both ARM64 and AMD64 architectures:
+
+```bash
+# Build the Docker image
+./scripts/build-local.sh
+
+# Build with verbose output
+./scripts/build-local.sh --verbose
+
+# Build for a specific platform
+./scripts/build-local.sh --platform="linux/amd64"
+```
 
 ## Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+
+services:
+  maistro:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: maistro:local
+    container_name: maistro
+    ports:
+      - "3000:3000"
+    volumes:
+      - maistro-data:/app/data
+    restart: unless-stopped
+    environment:
+      - NODE_ENV=production
+      # Add any other environment variables here
+
+volumes:
+  maistro-data:
+    name: maistro-data

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Create data directory if it doesn't exist
+mkdir -p /app/data/prompts
+
+# Start the application
+exec node src/server.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,15 +11,41 @@
         "cors": "^2.8.5",
         "cron-parser": "^4.9.0",
         "express": "^4.18.2",
+        "express-openapi": "^12.1.3",
         "fs-extra": "^11.2.0",
         "js-yaml": "^4.1.0",
         "morgan": "^1.10.0",
         "node-cron": "^3.0.3",
+        "swagger-ui-express": "^5.0.1",
         "ws": "^8.16.0"
       },
       "devDependencies": {
         "nodemon": "^3.0.3"
       }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -32,6 +58,63 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/anymatch": {
@@ -64,7 +147,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/basic-auth": {
@@ -209,6 +291,24 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -277,6 +377,20 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -305,6 +419,15 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/difunc": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/difunc/-/difunc-0.0.4.tgz",
+      "integrity": "sha512-zBiL4ALDmviHdoLC0g0G6wVme5bwAow9WfhcZLLopXCAWgg3AEf7RYTs2xugszIGulRHzEVDF/SHl9oyQU07Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "esprima": "^4.0.0"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -319,10 +442,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -369,6 +504,19 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -425,6 +573,45 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-normalize-query-params-middleware": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/express-normalize-query-params-middleware/-/express-normalize-query-params-middleware-0.5.1.tgz",
+      "integrity": "sha512-KUBjEukYL9KJkrphVX3ZgMHgMTdgaSJe+FIOeWwJIJpCw8UZQPIylt0MYddSyUwbms4LQ8RC4wmavcLUP9uduA==",
+      "license": "MIT"
+    },
+    "node_modules/express-openapi": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/express-openapi/-/express-openapi-12.1.3.tgz",
+      "integrity": "sha512-F570dVC5ENSkLu1SpDFPRQ13Y3a/7Udh0rfHyn3O1QrE81fPmlhnAo1JRgoNtbMRJ6goHNymxU1TVSllgFZBlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "express-normalize-query-params-middleware": "^0.5.0",
+        "openapi-framework": "^12.1.3",
+        "openapi-types": "^12.1.3"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -454,6 +641,22 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/forwarded": {
@@ -486,6 +689,15 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/fs-routes": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/fs-routes/-/fs-routes-12.1.3.tgz",
+      "integrity": "sha512-Vwxi5StpKj/pgH7yRpNpVFdaZr16z71KNTiYuZEYVET+MfZ31Zkf7oxUmNgyZxptG8BolRtdMP90agIhdyiozg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "glob": ">=7.1.6"
       }
     },
     "node_modules/fsevents": {
@@ -549,6 +761,29 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
+      "integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -560,6 +795,30 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gopd": {
@@ -677,6 +936,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-dir/-/is-dir-1.0.0.tgz",
+      "integrity": "sha512-vLwCNpTNkFC5k7SBRxPubhOCryeulkOsSkjbGyZ8eOzZmzMS+hSEO/Kn9ZOVhFNAlRZTFc4ZKql48hESuYUPIQ==",
+      "license": "MIT"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -685,6 +950,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -710,6 +984,27 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
+      "integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -722,6 +1017,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -732,6 +1033,21 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
+      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/luxon": {
@@ -823,6 +1139,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/morgan": {
@@ -986,6 +1311,134 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/openapi-default-setter": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-default-setter/-/openapi-default-setter-12.1.3.tgz",
+      "integrity": "sha512-wHKwvEuOWwke5WcQn8pyCTXT5WQ+rm9FpJmDeEVECEBWjEyB/MVLYfXi+UQeSHTTu2Tg4VDHHmzbjOqN6hYeLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-types": "^12.1.3"
+      }
+    },
+    "node_modules/openapi-framework": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-framework/-/openapi-framework-12.1.3.tgz",
+      "integrity": "sha512-p30PHWVXda9gGxm+t/1X2XvEcufW1YhzeDQwc5SsgDnBXt8gkuu1SwrioGJ66wxVYEzfSRTTf/FMLhI49ut8fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "difunc": "0.0.4",
+        "fs-routes": "^12.1.3",
+        "glob": "*",
+        "is-dir": "^1.0.0",
+        "js-yaml": "^3.10.0",
+        "openapi-default-setter": "^12.1.3",
+        "openapi-request-coercer": "^12.1.3",
+        "openapi-request-validator": "^12.1.3",
+        "openapi-response-validator": "^12.1.3",
+        "openapi-schema-validator": "^12.1.3",
+        "openapi-security-handler": "^12.1.3",
+        "openapi-types": "^12.1.3",
+        "ts-log": "^2.1.4"
+      }
+    },
+    "node_modules/openapi-framework/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/openapi-framework/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/openapi-jsonschema-parameters": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-jsonschema-parameters/-/openapi-jsonschema-parameters-12.1.3.tgz",
+      "integrity": "sha512-aHypKxWHwu2lVqfCIOCZeJA/2NTDiP63aPwuoIC+5ksLK5/IQZ3oKTz7GiaIegz5zFvpMDxDvLR2DMQQSkOAug==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-types": "^12.1.3"
+      }
+    },
+    "node_modules/openapi-request-coercer": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-request-coercer/-/openapi-request-coercer-12.1.3.tgz",
+      "integrity": "sha512-CT2ZDhBmAZpHhAzHhEN+/J5oMK3Ds99ayLLdXh2Aw1DCcn72EM8VuIGVwG5fSjvkMsgtn7FgltFosHqeM6PRFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-types": "^12.1.3",
+        "ts-log": "^2.1.4"
+      }
+    },
+    "node_modules/openapi-request-validator": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-request-validator/-/openapi-request-validator-12.1.3.tgz",
+      "integrity": "sha512-HW1sG00A9Hp2oS5g8CBvtaKvRAc4h5E4ksmuC5EJgmQ+eAUacL7g+WaYCrC7IfoQaZrjxDfeivNZUye/4D8pwA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.3.0",
+        "ajv-formats": "^2.1.0",
+        "content-type": "^1.0.4",
+        "openapi-jsonschema-parameters": "^12.1.3",
+        "openapi-types": "^12.1.3",
+        "ts-log": "^2.1.4"
+      }
+    },
+    "node_modules/openapi-response-validator": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-response-validator/-/openapi-response-validator-12.1.3.tgz",
+      "integrity": "sha512-beZNb6r1SXAg1835S30h9XwjE596BYzXQFAEZlYAoO2imfxAu5S7TvNFws5k/MMKMCOFTzBXSjapqEvAzlblrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.4.0",
+        "openapi-types": "^12.1.3"
+      }
+    },
+    "node_modules/openapi-schema-validator": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-schema-validator/-/openapi-schema-validator-12.1.3.tgz",
+      "integrity": "sha512-xTHOmxU/VQGUgo7Cm0jhwbklOKobXby+/237EG967+3TQEYJztMgX9Q5UE2taZKwyKPUq0j11dngpGjUuxz1hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.1.0",
+        "ajv-formats": "^2.0.2",
+        "lodash.merge": "^4.6.1",
+        "openapi-types": "^12.1.3"
+      }
+    },
+    "node_modules/openapi-security-handler": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-security-handler/-/openapi-security-handler-12.1.3.tgz",
+      "integrity": "sha512-25UTAflxqqpjCLrN6rRhINeM1L+MCDixMltiAqtBa9Zz/i7UkWwYwdzqgZY3Cx3vRZElFD09brYxo5VleeP3HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-types": "^12.1.3"
+      }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT"
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -993,6 +1446,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
@@ -1084,6 +1562,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -1185,6 +1672,27 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -1257,6 +1765,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -1270,6 +1790,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -1277,6 +1803,102 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-color": {
@@ -1290,6 +1912,30 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.20.1.tgz",
+      "integrity": "sha512-qBPCis2w8nP4US7SvUxdJD3OwKcqiWeZmjN2VWhq2v+ESZEXOP/7n4DeiOiiZcGYTKMHAHUUrroHaTsjUWTEGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/to-regex-range": {
@@ -1323,6 +1969,12 @@
       "bin": {
         "nodetouch": "bin/nodetouch.js"
       }
+    },
+    "node_modules/ts-log": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.2.7.tgz",
+      "integrity": "sha512-320x5Ggei84AxzlXp91QkIGSw5wgaLT6GeAH0KsqDmRZdVWW2OiSeVvElVoatk3f7nicwXlElXsoFkARiGE2yg==",
+      "license": "MIT"
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -1387,6 +2039,112 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
     "cors": "^2.8.5",
     "cron-parser": "^4.9.0",
     "express": "^4.18.2",
+    "express-openapi": "^12.1.3",
     "fs-extra": "^11.2.0",
     "js-yaml": "^4.1.0",
     "morgan": "^1.10.0",
     "node-cron": "^3.0.3",
+    "swagger-ui-express": "^5.0.1",
     "ws": "^8.16.0"
   },
   "devDependencies": {

--- a/scripts/build-local.sh
+++ b/scripts/build-local.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+set -e
+
+# Force immediate output
+exec 1>&1
+
+# This script provides a lightweight local development build pipeline
+# that builds Docker images for both ARM and AMD64 architectures.
+
+# Parse command line arguments
+VERBOSE=false
+PLATFORMS="linux/amd64,linux/arm64"
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --verbose) VERBOSE=true ;;
+        --platform=*) PLATFORMS="${1#*=}" ;;
+        *) echo "Unknown parameter: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+# Create temp directory for logs if it doesn't exist
+TEMP_DIR="/tmp/maistro-docker"
+mkdir -p "$TEMP_DIR"
+
+# Setup colored output
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+CHECK_MARK="✓"
+X_MARK="✗"
+WARNING_MARK="⚠"
+
+# Function to check log file size and show warning if needed
+check_log_size() {
+    local log_file=$1
+    if [ -f "$log_file" ]; then
+        local line_count=$(wc -l < "$log_file")
+        if [ $line_count -gt 100 ]; then
+            echo -e "${YELLOW}${WARNING_MARK} Large log file detected ($line_count lines)${NC}"
+            echo "  Tips for viewing large logs:"
+            echo "  • head -n 20 $log_file     (view first 20 lines)"
+            echo "  • tail -n 20 $log_file     (view last 20 lines)"
+            echo "  • less $log_file           (scroll through file)"
+            echo "  • grep 'error' $log_file   (search for specific terms)"
+        fi
+    fi
+}
+
+# Function to run a step and show its status
+run_step() {
+    local step_name=$1
+    local log_file="$TEMP_DIR/$2.log"
+    local command=$3
+    
+    echo -n "→ $step_name... "
+    
+    if [ "$VERBOSE" = true ]; then
+        if eval "$command"; then
+            echo -e "${GREEN}${CHECK_MARK} Success${NC}"
+            return 0
+        else
+            echo -e "${RED}${X_MARK} Failed${NC}"
+            return 1
+        fi
+    else
+        if eval "$command > '$log_file' 2>&1"; then
+            echo -e "${GREEN}${CHECK_MARK} Success${NC} (log: $log_file)"
+            check_log_size "$log_file"
+            return 0
+        else
+            echo -e "${RED}${X_MARK} Failed${NC} (see details in $log_file)"
+            check_log_size "$log_file"
+            return 1
+        fi
+    fi
+}
+
+# Install dependencies
+run_step "Installing dependencies" "npm-install" "npm install" || exit 1
+
+# Build Docker image with multi-architecture support
+echo "→ Building Docker images for platforms: $PLATFORMS"
+if [ "$VERBOSE" = true ]; then
+    if docker buildx build --platform $PLATFORMS -t maistro:local --load .; then
+        echo -e "${GREEN}${CHECK_MARK} Docker build successful${NC}"
+    else
+        echo -e "${RED}${X_MARK} Docker build failed${NC}"
+        exit 1
+    fi
+else
+    DOCKER_LOG="$TEMP_DIR/docker-build.log"
+    if docker buildx build --platform $PLATFORMS -t maistro:local --load . > "$DOCKER_LOG" 2>&1; then
+        echo -e "${GREEN}${CHECK_MARK} Docker build successful${NC} (log: $DOCKER_LOG)"
+        check_log_size "$DOCKER_LOG"
+    else
+        echo -e "${RED}${X_MARK} Docker build failed${NC} (see details in $DOCKER_LOG)"
+        check_log_size "$DOCKER_LOG"
+        exit 1
+    fi
+fi
+
+echo -e "\n${GREEN}Build complete!${NC} Image tagged as maistro:local"

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+# This script runs the Maistro Docker container using docker-compose
+# for local development and testing.
+
+# Parse command line arguments
+DETACHED=false
+ENV_FILE=""
+COMPOSE_FILE="../docker-compose.yml"
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --detached|-d) DETACHED=true ;;
+        --env-file=*) ENV_FILE="--env-file=${1#*=}" ;;
+        --compose-file=*) COMPOSE_FILE="${1#*=}" ;;
+        *) echo "Unknown parameter: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+# Determine if we should run in detached mode
+DETACH_FLAG=""
+if [ "$DETACHED" = true ]; then
+    DETACH_FLAG="-d"
+    echo "Running in detached mode"
+fi
+
+# Navigate to the directory containing the docker-compose.yml file
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+# Run the container using docker-compose
+echo "Starting Maistro container using docker-compose..."
+
+docker-compose $ENV_FILE up $DETACH_FLAG --build
+
+if [ "$DETACHED" = true ]; then
+    echo "Container started in background. To view logs: docker-compose logs -f"
+    echo "To stop: docker-compose down"
+else
+    echo "Container stopped."
+fi

--- a/scripts/run-local.sh
+++ b/scripts/run-local.sh
@@ -1,23 +1,173 @@
 #!/bin/bash
 set -e
 
+# Force immediate output
+exec 1>&1
+
 # This script runs the Maistro Docker container using docker-compose
-# for local development and testing.
+# with support for custom volume configuration.
+
+# Setup colored output
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+BOLD='\033[1m'
+
+# Navigate to the project root directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+# Configuration file path
+CONFIG_FILE=".maistro-docker-config"
 
 # Parse command line arguments
 DETACHED=false
 ENV_FILE=""
-COMPOSE_FILE="../docker-compose.yml"
+COMPOSE_FILE="docker-compose.yml"
+SKIP_CONFIG=false
+RESET_CONFIG=false
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         --detached|-d) DETACHED=true ;;
         --env-file=*) ENV_FILE="--env-file=${1#*=}" ;;
         --compose-file=*) COMPOSE_FILE="${1#*=}" ;;
+        --skip-config) SKIP_CONFIG=true ;;
+        --reset-config) RESET_CONFIG=true ;;
+        --help|-h)
+            echo -e "${BOLD}Maistro Docker Runner${NC}"
+            echo "Usage: $0 [options]"
+            echo ""
+            echo "Options:"
+            echo "  --detached, -d           Run container in detached mode"
+            echo "  --env-file=FILE          Specify an environment file"
+            echo "  --compose-file=FILE      Specify a custom docker-compose file"
+            echo "  --skip-config            Skip configuration prompts"
+            echo "  --reset-config           Reset configuration and prompt again"
+            echo "  --help, -h               Show this help message"
+            echo ""
+            echo "Volume Configuration:"
+            echo "  This script allows you to choose between Docker-managed volumes"
+            echo "  or a custom host directory for persistent configuration."
+            exit 0
+            ;;
         *) echo "Unknown parameter: $1"; exit 1 ;;
     esac
     shift
 done
+
+# Function to prompt user for input with a default value
+prompt_with_default() {
+    local prompt=$1
+    local default=$2
+    local response
+
+    echo -en "${prompt} [${default}]: "
+    read response
+    echo "${response:-$default}"
+}
+
+# Function to create a temporary docker-compose override file
+create_compose_override() {
+    local volume_type=$1
+    local host_path=$2
+    local override_file="docker-compose.override.yml"
+
+    if [ "$volume_type" = "host" ]; then
+        # Create host directory if it doesn't exist
+        mkdir -p "$host_path"
+        
+        # Create override file for host volume
+        cat > "$override_file" <<EOL
+version: '3.8'
+
+services:
+  maistro:
+    volumes:
+      - ${host_path}:/app/data
+EOL
+    else
+        # Create override file for named volume (or remove if exists)
+        if [ -f "$override_file" ]; then
+            rm "$override_file"
+        fi
+    fi
+}
+
+# Function to configure volume settings
+configure_volumes() {
+    echo -e "\n${BOLD}Maistro Docker Configuration${NC}"
+    echo -e "This will configure how Maistro stores its data.\n"
+    
+    echo -e "${BOLD}Volume Configuration Options:${NC}"
+    echo "1) Docker-managed volume (recommended, easier to manage)"
+    echo "2) Custom host directory (advanced, direct access to files)"
+    echo ""
+    
+    local choice
+    while true; do
+        echo -n "Select option [1]: "
+        read choice
+        choice=${choice:-1}
+        
+        if [ "$choice" = "1" ]; then
+            echo -e "\n${GREEN}Using Docker-managed volume${NC}"
+            echo "VOLUME_TYPE=docker" > "$CONFIG_FILE"
+            break
+        elif [ "$choice" = "2" ]; then
+            echo -e "\n${YELLOW}Using custom host directory${NC}"
+            
+            # Get host directory path
+            local default_path="$HOME/.maistro-data"
+            echo -n "Enter host directory path [$default_path]: "
+            read host_path
+            host_path=${host_path:-$default_path}
+            
+            # Save configuration
+            echo "VOLUME_TYPE=host" > "$CONFIG_FILE"
+            echo "HOST_PATH=\"$host_path\"" >> "$CONFIG_FILE"
+            
+            echo -e "\n${GREEN}Configuration saved.${NC}"
+            echo "Data will be stored in: $host_path"
+            break
+        else
+            echo -e "${YELLOW}Invalid option. Please select 1 or 2.${NC}"
+        fi
+    done
+}
+
+# Check if we should reset configuration
+if [ "$RESET_CONFIG" = true ]; then
+    if [ -f "$CONFIG_FILE" ]; then
+        rm "$CONFIG_FILE"
+        echo -e "${YELLOW}Configuration reset.${NC}"
+    fi
+fi
+
+# Check if configuration exists or if we should skip configuration
+if [ ! -f "$CONFIG_FILE" ] && [ "$SKIP_CONFIG" = false ]; then
+    configure_volumes
+fi
+
+# Load configuration
+if [ -f "$CONFIG_FILE" ]; then
+    source "$CONFIG_FILE"
+else
+    # Default to docker volume if no config
+    VOLUME_TYPE="docker"
+fi
+
+# Create docker-compose override based on configuration
+if [ "$VOLUME_TYPE" = "host" ]; then
+    # Remove any quotes from the path
+    HOST_PATH=$(echo $HOST_PATH | sed 's/^"//;s/"$//')
+    echo -e "${BLUE}Using host directory for data: ${HOST_PATH}${NC}"
+    create_compose_override "host" "$HOST_PATH"
+else
+    echo -e "${BLUE}Using Docker-managed volume for data${NC}"
+    create_compose_override "docker"
+fi
 
 # Determine if we should run in detached mode
 DETACH_FLAG=""
@@ -26,18 +176,15 @@ if [ "$DETACHED" = true ]; then
     echo "Running in detached mode"
 fi
 
-# Navigate to the directory containing the docker-compose.yml file
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR/.."
-
 # Run the container using docker-compose
-echo "Starting Maistro container using docker-compose..."
+echo -e "\n${BOLD}Starting Maistro container...${NC}"
 
 docker-compose $ENV_FILE up $DETACH_FLAG --build
 
 if [ "$DETACHED" = true ]; then
-    echo "Container started in background. To view logs: docker-compose logs -f"
+    echo -e "\n${GREEN}Container started in background.${NC}"
+    echo "To view logs: docker-compose logs -f"
     echo "To stop: docker-compose down"
 else
-    echo "Container stopped."
+    echo -e "\n${GREEN}Container stopped.${NC}"
 fi

--- a/src/api/openapi.js
+++ b/src/api/openapi.js
@@ -1,0 +1,547 @@
+module.exports = {
+  openapi: '3.0.0',
+  info: {
+    title: 'Maistro API',
+    version: '0.1.0',
+    description: 'API documentation for the Maistro prompt automation tool',
+    license: {
+      name: 'MIT',
+      url: 'https://opensource.org/licenses/MIT',
+    },
+    contact: {
+      name: 'Maistro Support',
+      url: 'https://github.com/forayconsulting/maistro',
+    },
+  },
+  servers: [
+    {
+      url: 'http://localhost:3000',
+      description: 'Development server',
+    },
+  ],
+  components: {
+    schemas: {
+      Config: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            description: 'Unique identifier for the configuration',
+            example: 'config-1615478362547',
+          },
+          name: {
+            type: 'string',
+            description: 'Name of the configuration',
+            example: 'Daily Report Generator',
+          },
+          path: {
+            type: 'string',
+            description: 'Folder path for the configuration',
+            example: 'reports/daily',
+          },
+          prompts: {
+            type: 'array',
+            description: 'List of prompts to execute in sequence',
+            items: {
+              oneOf: [
+                {
+                  type: 'string',
+                  description: 'Simple prompt text',
+                },
+                {
+                  type: 'object',
+                  properties: {
+                    text: {
+                      type: 'string',
+                      description: 'Prompt text',
+                    },
+                    mcpServerIds: {
+                      type: 'array',
+                      items: {
+                        type: 'string',
+                      },
+                      description: 'List of MCP server IDs to use with this prompt',
+                    },
+                    model: {
+                      type: 'string',
+                      description: 'Model to use for this prompt',
+                      nullable: true,
+                    },
+                  },
+                },
+              ],
+            },
+          },
+          trigger: {
+            type: 'object',
+            properties: {
+              enabled: {
+                type: 'boolean',
+                description: 'Whether the trigger is enabled',
+              },
+              configId: {
+                type: 'string',
+                description: 'ID of the configuration to trigger',
+              },
+              preserveSession: {
+                type: 'boolean',
+                description: 'Whether to preserve the session when triggering',
+              },
+            },
+          },
+          schedule: {
+            type: 'object',
+            properties: {
+              enabled: {
+                type: 'boolean',
+                description: 'Whether scheduling is enabled',
+              },
+              frequency: {
+                type: 'string',
+                enum: ['daily', 'weekly', 'monthly'],
+                description: 'Frequency of execution',
+              },
+              time: {
+                type: 'string',
+                description: 'Time of execution (HH:MM)',
+                example: '09:00',
+              },
+              days: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  enum: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+                },
+                description: 'Days of the week for weekly frequency',
+              },
+              dayOfMonth: {
+                type: 'integer',
+                description: 'Day of the month for monthly frequency',
+                minimum: 1,
+                maximum: 31,
+              },
+            },
+          },
+        },
+        required: ['id', 'name', 'prompts'],
+      },
+      Folder: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description: 'Full path of the folder',
+            example: 'reports/daily',
+          },
+          name: {
+            type: 'string',
+            description: 'Name of the folder',
+            example: 'daily',
+          },
+          parentPath: {
+            type: 'string',
+            description: 'Path of the parent folder',
+            example: 'reports',
+          },
+        },
+        required: ['path', 'name'],
+      },
+      MCPServer: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            description: 'Unique identifier for the MCP server',
+            example: 'mcp-server-1615478362547',
+          },
+          name: {
+            type: 'string',
+            description: 'Name of the MCP server',
+            example: 'Weather API',
+          },
+          command: {
+            type: 'string',
+            description: 'Command to execute the MCP server',
+            example: 'node',
+          },
+          args: {
+            type: 'string',
+            description: 'Arguments for the command',
+            example: '/path/to/weather-server.js',
+          },
+          env: {
+            type: 'object',
+            description: 'Environment variables for the MCP server',
+            additionalProperties: {
+              type: 'string',
+            },
+            example: {
+              API_KEY: 'your-api-key',
+            },
+          },
+          description: {
+            type: 'string',
+            description: 'Description of the MCP server',
+            example: 'Provides weather data via the OpenWeather API',
+          },
+          defaultEnabled: {
+            type: 'boolean',
+            description: 'Whether the MCP server is enabled by default for new prompts',
+          },
+        },
+        required: ['id', 'name', 'command'],
+      },
+      Model: {
+        type: 'object',
+        properties: {
+          defaultModel: {
+            type: 'string',
+            description: 'Default model to use for prompts',
+            example: 'anthropic/claude-3.7-sonnet',
+          },
+          availableModels: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+            description: 'List of available models',
+            example: [
+              'anthropic/claude-3.7-sonnet:thinking',
+              'anthropic/claude-3.7-sonnet',
+              'openai/o3-mini-high',
+              'openai/gpt-4o-2024-11-20',
+            ],
+          },
+          apiKey: {
+            type: 'string',
+            description: 'API key status',
+            example: '***API KEY STORED***',
+          },
+        },
+      },
+      Error: {
+        type: 'object',
+        properties: {
+          error: {
+            type: 'string',
+            description: 'Error message',
+          },
+        },
+        required: ['error'],
+      },
+      Success: {
+        type: 'object',
+        properties: {
+          success: {
+            type: 'boolean',
+            description: 'Success status',
+            example: true,
+          },
+          message: {
+            type: 'string',
+            description: 'Success message',
+            example: 'Operation completed successfully',
+          },
+        },
+        required: ['success'],
+      },
+    },
+    responses: {
+      Error: {
+        description: 'Error response',
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/Error',
+            },
+          },
+        },
+      },
+      Success: {
+        description: 'Success response',
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/Success',
+            },
+          },
+        },
+      },
+    },
+  },
+  paths: {
+    '/api/health': {
+      get: {
+        summary: 'Health check endpoint',
+        description: 'Returns the health status of the API',
+        operationId: 'getHealth',
+        responses: {
+          200: {
+            description: 'Health status',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    status: {
+                      type: 'string',
+                      example: 'ok'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    '/api/configs': {
+      get: {
+        summary: 'Get all configurations',
+        description: 'Returns a list of all configurations, optionally filtered by folder path',
+        operationId: 'getConfigs',
+        parameters: [
+          {
+            name: 'folderPath',
+            in: 'query',
+            description: 'Filter configurations by folder path',
+            required: false,
+            schema: {
+              type: 'string'
+            }
+          }
+        ],
+        responses: {
+          200: {
+            description: 'List of configurations',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: {
+                    $ref: '#/components/schemas/Config'
+                  }
+                }
+              }
+            }
+          },
+          500: {
+            $ref: '#/components/responses/Error'
+          }
+        }
+      },
+      post: {
+        summary: 'Create or update a configuration',
+        description: 'Creates a new configuration or updates an existing one',
+        operationId: 'saveConfig',
+        requestBody: {
+          description: 'Configuration to save',
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/Config'
+              }
+            }
+          }
+        },
+        responses: {
+          200: {
+            description: 'Configuration saved successfully',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    success: {
+                      type: 'boolean',
+                      example: true
+                    },
+                    config: {
+                      $ref: '#/components/schemas/Config'
+                    }
+                  }
+                }
+              }
+            }
+          },
+          500: {
+            $ref: '#/components/responses/Error'
+          }
+        }
+      }
+    },
+    '/api/configs/{id}': {
+      delete: {
+        summary: 'Delete a configuration',
+        description: 'Deletes a configuration by ID',
+        operationId: 'deleteConfig',
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            description: 'Configuration ID',
+            required: true,
+            schema: {
+              type: 'string'
+            }
+          }
+        ],
+        responses: {
+          200: {
+            description: 'Configuration deleted successfully',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Success'
+                }
+              }
+            }
+          },
+          500: {
+            $ref: '#/components/responses/Error'
+          }
+        }
+      }
+    },
+    '/api/configs/{id}/move': {
+      put: {
+        summary: 'Move a configuration to a folder',
+        description: 'Moves a configuration to a specified folder',
+        operationId: 'moveConfig',
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            description: 'Configuration ID',
+            required: true,
+            schema: {
+              type: 'string'
+            }
+          }
+        ],
+        requestBody: {
+          description: 'Folder path to move the configuration to',
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  folderPath: {
+                    type: 'string',
+                    description: 'Target folder path',
+                    example: 'reports/daily'
+                  }
+                },
+                required: ['folderPath']
+              }
+            }
+          }
+        },
+        responses: {
+          200: {
+            description: 'Configuration moved successfully',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    success: {
+                      type: 'boolean',
+                      example: true
+                    },
+                    config: {
+                      $ref: '#/components/schemas/Config'
+                    }
+                  }
+                }
+              }
+            }
+          },
+          400: {
+            description: 'Bad request',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Error'
+                }
+              }
+            }
+          },
+          404: {
+            description: 'Configuration not found',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Error'
+                }
+              }
+            }
+          },
+          500: {
+            $ref: '#/components/responses/Error'
+          }
+        }
+      }
+    },
+    '/api/run/{id}': {
+      post: {
+        summary: 'Run a configuration',
+        description: 'Executes a configuration by ID',
+        operationId: 'runConfig',
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            description: 'Configuration ID',
+            required: true,
+            schema: {
+              type: 'string'
+            }
+          }
+        ],
+        responses: {
+          200: {
+            description: 'Execution started or queued',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    success: {
+                      type: 'boolean',
+                      example: true
+                    },
+                    message: {
+                      type: 'string',
+                      example: 'Execution started'
+                    },
+                    needsReconnect: {
+                      type: 'boolean',
+                      description: 'Indicates if the client needs to reconnect the WebSocket',
+                      example: false
+                    }
+                  }
+                }
+              }
+            }
+          },
+          404: {
+            description: 'Configuration not found',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/Error'
+                }
+              }
+            }
+          },
+          500: {
+            $ref: '#/components/responses/Error'
+          }
+        }
+      }
+    }
+  },
+};

--- a/src/api/paths/configs.js
+++ b/src/api/paths/configs.js
@@ -1,0 +1,117 @@
+module.exports = function(configManager, crontabManager) {
+  let operations = {
+    GET,
+    POST
+  };
+
+  function GET(req, res) {
+    try {
+      // Check if a folder path is specified in the query parameters
+      const folderPath = req.query.folderPath !== undefined ? req.query.folderPath : undefined;
+      const configs = configManager.getAllConfigs(folderPath);
+      res.json(configs);
+    } catch (error) {
+      console.error('Error getting configurations:', error);
+      res.status(500).json({ error: error.message });
+    }
+  }
+
+  function POST(req, res) {
+    try {
+      const config = req.body;
+      configManager.saveConfig(config);
+      
+      // Update crontab if scheduling is enabled
+      if (config.schedule && config.schedule.enabled) {
+        crontabManager.updateCronJob(config);
+      } else {
+        crontabManager.removeCronJob(config.id);
+      }
+      
+      res.json({ success: true, config });
+    } catch (error) {
+      console.error('Error saving config:', error);
+      res.status(500).json({ error: error.message });
+    }
+  }
+
+  // OpenAPI specification for GET operation
+  GET.apiDoc = {
+    summary: 'Get all configurations',
+    description: 'Returns a list of all configurations, optionally filtered by folder path',
+    operationId: 'getConfigs',
+    parameters: [
+      {
+        name: 'folderPath',
+        in: 'query',
+        description: 'Filter configurations by folder path',
+        required: false,
+        schema: {
+          type: 'string'
+        }
+      }
+    ],
+    responses: {
+      200: {
+        description: 'List of configurations',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'array',
+              items: {
+                $ref: '#/components/schemas/Config'
+              }
+            }
+          }
+        }
+      },
+      500: {
+        $ref: '#/components/responses/Error'
+      }
+    }
+  };
+
+  // OpenAPI specification for POST operation
+  POST.apiDoc = {
+    summary: 'Create or update a configuration',
+    description: 'Creates a new configuration or updates an existing one',
+    operationId: 'saveConfig',
+    requestBody: {
+      description: 'Configuration to save',
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/components/schemas/Config'
+          }
+        }
+      }
+    },
+    responses: {
+      200: {
+        description: 'Configuration saved successfully',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                success: {
+                  type: 'boolean',
+                  example: true
+                },
+                config: {
+                  $ref: '#/components/schemas/Config'
+                }
+              }
+            }
+          }
+        }
+      },
+      500: {
+        $ref: '#/components/responses/Error'
+      }
+    }
+  };
+
+  return operations;
+};

--- a/src/api/paths/configs/{id}.js
+++ b/src/api/paths/configs/{id}.js
@@ -1,0 +1,52 @@
+module.exports = function(configManager, crontabManager) {
+  let operations = {
+    DELETE
+  };
+
+  function DELETE(req, res) {
+    try {
+      const id = req.params.id;
+      configManager.deleteConfig(id);
+      crontabManager.removeCronJob(id);
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Error deleting config:', error);
+      res.status(500).json({ error: error.message });
+    }
+  }
+
+  // OpenAPI specification for DELETE operation
+  DELETE.apiDoc = {
+    summary: 'Delete a configuration',
+    description: 'Deletes a configuration by ID',
+    operationId: 'deleteConfig',
+    parameters: [
+      {
+        name: 'id',
+        in: 'path',
+        description: 'Configuration ID',
+        required: true,
+        schema: {
+          type: 'string'
+        }
+      }
+    ],
+    responses: {
+      200: {
+        description: 'Configuration deleted successfully',
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/Success'
+            }
+          }
+        }
+      },
+      500: {
+        $ref: '#/components/responses/Error'
+      }
+    }
+  };
+
+  return operations;
+};

--- a/src/api/paths/configs/{id}/move.js
+++ b/src/api/paths/configs/{id}/move.js
@@ -1,0 +1,110 @@
+module.exports = function(configManager) {
+  let operations = {
+    PUT
+  };
+
+  function PUT(req, res) {
+    try {
+      const configId = req.params.id;
+      const { folderPath } = req.body;
+      
+      if (folderPath === undefined) {
+        return res.status(400).json({ error: 'No folder path provided' });
+      }
+      
+      const config = configManager.moveConfigToFolder(configId, folderPath);
+      
+      if (!config) {
+        return res.status(404).json({ error: 'Configuration not found' });
+      }
+      
+      res.json({ success: true, config });
+    } catch (error) {
+      console.error('Error moving configuration:', error);
+      res.status(500).json({ error: error.message });
+    }
+  }
+
+  // OpenAPI specification for PUT operation
+  PUT.apiDoc = {
+    summary: 'Move a configuration to a folder',
+    description: 'Moves a configuration to a specified folder',
+    operationId: 'moveConfig',
+    parameters: [
+      {
+        name: 'id',
+        in: 'path',
+        description: 'Configuration ID',
+        required: true,
+        schema: {
+          type: 'string'
+        }
+      }
+    ],
+    requestBody: {
+      description: 'Folder path to move the configuration to',
+      required: true,
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              folderPath: {
+                type: 'string',
+                description: 'Target folder path',
+                example: 'reports/daily'
+              }
+            },
+            required: ['folderPath']
+          }
+        }
+      }
+    },
+    responses: {
+      200: {
+        description: 'Configuration moved successfully',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                success: {
+                  type: 'boolean',
+                  example: true
+                },
+                config: {
+                  $ref: '#/components/schemas/Config'
+                }
+              }
+            }
+          }
+        }
+      },
+      400: {
+        description: 'Bad request',
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/Error'
+            }
+          }
+        }
+      },
+      404: {
+        description: 'Configuration not found',
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/Error'
+            }
+          }
+        }
+      },
+      500: {
+        $ref: '#/components/responses/Error'
+      }
+    }
+  };
+
+  return operations;
+};

--- a/src/api/paths/health.js
+++ b/src/api/paths/health.js
@@ -1,0 +1,36 @@
+module.exports = function() {
+  let operations = {
+    GET
+  };
+
+  function GET(req, res) {
+    res.status(200).json({ status: 'ok' });
+  }
+
+  // OpenAPI specification for this endpoint
+  GET.apiDoc = {
+    summary: 'Health check endpoint',
+    description: 'Returns the health status of the API',
+    operationId: 'getHealth',
+    responses: {
+      200: {
+        description: 'Health status',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                status: {
+                  type: 'string',
+                  example: 'ok'
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  };
+
+  return operations;
+};

--- a/src/api/paths/run/{id}.js
+++ b/src/api/paths/run/{id}.js
@@ -1,0 +1,98 @@
+module.exports = function(configManager, executionManager) {
+  let operations = {
+    POST
+  };
+
+  function POST(req, res) {
+    try {
+      const id = req.params.id;
+      const config = configManager.getConfigById(id);
+      
+      if (!config) {
+        return res.status(404).json({ error: 'Configuration not found' });
+      }
+      
+      // Get the WebSocket connection
+      const ws = req.app.locals.connections.get(id);
+      
+      if (!ws || ws.readyState !== 1) { // WebSocket.OPEN = 1
+        console.warn(`No active WebSocket connection found for config ID: ${id}. Waiting for connection...`);
+        
+        // Return success but let client know of potential issue
+        return res.json({ 
+          success: true, 
+          message: 'Execution queued, waiting for WebSocket connection',
+          needsReconnect: true 
+        });
+      }
+      
+      // Start execution in background
+      executionManager.executeConfig(config, ws);
+      
+      res.json({ success: true, message: 'Execution started' });
+    } catch (error) {
+      console.error('Error starting execution:', error);
+      res.status(500).json({ error: error.message });
+    }
+  }
+
+  // OpenAPI specification for POST operation
+  POST.apiDoc = {
+    summary: 'Run a configuration',
+    description: 'Executes a configuration by ID',
+    operationId: 'runConfig',
+    parameters: [
+      {
+        name: 'id',
+        in: 'path',
+        description: 'Configuration ID',
+        required: true,
+        schema: {
+          type: 'string'
+        }
+      }
+    ],
+    responses: {
+      200: {
+        description: 'Execution started or queued',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                success: {
+                  type: 'boolean',
+                  example: true
+                },
+                message: {
+                  type: 'string',
+                  example: 'Execution started'
+                },
+                needsReconnect: {
+                  type: 'boolean',
+                  description: 'Indicates if the client needs to reconnect the WebSocket',
+                  example: false
+                }
+              }
+            }
+          }
+        }
+      },
+      404: {
+        description: 'Configuration not found',
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/components/schemas/Error'
+            }
+          }
+        }
+      },
+      500: {
+        $ref: '#/components/responses/Error'
+      }
+    }
+  };
+
+  return operations;
+};


### PR DESCRIPTION
# Add Swagger UI Documentation

## Overview
This PR adds Swagger UI documentation to the REST API endpoints, making it easier for developers to understand and interact with the API. The documentation is accessible at the `/api-docs` endpoint and provides a user-friendly interface for exploring the available endpoints, their parameters, and response formats.

## Changes
- Added OpenAPI specification in `src/api/openapi.js`
- Integrated Swagger UI into the Express server
- Documented all existing API endpoints:
  - Health check endpoint
  - Config management endpoints
  - Run execution endpoints
- Added proper request/response schemas and examples

## Benefits
- Improved developer experience with interactive API documentation
- Self-documenting API that stays in sync with the codebase
- Easier onboarding for new developers
- Simplified API testing and exploration

## How to Use
After starting the server, navigate to `/api-docs` in your browser to access the Swagger UI interface. From there, you can:
- Browse all available endpoints
- See required parameters and response formats
- Test API calls directly from the UI
- Download the OpenAPI specification

This enhancement maintains backward compatibility with all existing API functionality while adding valuable documentation.